### PR TITLE
bump llamacpp tag version

### DIFF
--- a/llama.cpp/00-clone.sh
+++ b/llama.cpp/00-clone.sh
@@ -5,7 +5,7 @@ source "$(dirname "$0")"/../util/args.sh "$@"
 
 mkdir -p "${OUT_DIR}/llama.cpp"
 cd "${OUT_DIR}/llama.cpp"
-do_clone llama.cpp https://github.com/ggerganov/llama.cpp b1500
+do_clone llama.cpp https://github.com/ggerganov/llama.cpp b2000
 
 mkdir models
 cd models


### PR DESCRIPTION
Bump llamacpp versioning from b1500-b2000. Things brings with it far greater test coverage. Tested with scale release v1.3.0