### PR TITLE
Add NIXL to test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Contributions welcome!
 | llama.cpp      |                   | ✅     | ✅     | ✅      | ✅      | ✅      | ✅     |
 | llm.c          | 7ecd8906afe6ed... | ❌      | ❌      | ❌       | ❌       | ❌       | ❌      |
 | MAGMA          | v2.9.0            | ❌      | ❌      | ❌       | ❌       | ❌       | ❌      |
+| NIXL           | e128059af332df... | ❓     | ❓     | ❓      | ❓      | ❓      | ❓     |
 | nvflip         | 1eb247c           | ✅     | ✅     | ✅      | ✅      | ✅      | ❌     |
 | OpenCV         | 725e440           | ❌      | ❌      | ❌       | ❌       | ❌       | ❌      |
 | openmpi        | v4.1              | ✅     | ✅     | ✅      | ✅      | ✅      | ✅     |

--- a/nixl/00-clone.sh
+++ b/nixl/00-clone.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Clone NIXL and its UCX dependency at the versions pinned in versions.txt.
+
+set -ETeuo pipefail
+
+# shellcheck source=../util/git.sh
+source "$(dirname "$0")/../util/git.sh"
+
+do_clone_hash nixl https://github.com/ai-dynamo/nixl.git "$(get_version nixl)"
+do_clone_hash ucx https://github.com/openucx/ucx.git "$(get_version ucx)"

--- a/nixl/01-build.sh
+++ b/nixl/01-build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Build UCX from source, then build NIXL against it. Run after 00-clone.sh
+# from the same working directory.
+
+set -ETeuo pipefail
+
+# Build UCX from source. NIXL requires UCX with --enable-mt (multi-thread
+# support). Ubuntu's packaged UCX is too old (1.16) and lacks the API NIXL
+# uses. We build UCX 1.21.x (NIXL's tested version) against the CUDA toolkit
+# made available via test.sh's environment setup.
+mkdir -p ucx-install
+ucx_install_dir="$(realpath ucx-install)"
+(
+  cd ucx
+  ./autogen.sh
+  ./configure \
+    --prefix="${ucx_install_dir}" \
+    --with-cuda="${CUDA_DIR}" \
+    --enable-mt
+  make -j"$(nproc)"
+  make install
+)
+
+# Make the freshly-built UCX visible to the NIXL build.
+export PKG_CONFIG_PATH="${ucx_install_dir}/lib/pkgconfig:${PKG_CONFIG_PATH-}"
+export LD_LIBRARY_PATH="${ucx_install_dir}/lib:${LD_LIBRARY_PATH-}"
+
+# Configure NIXL. Meson will discover CUDA from the environment variables
+# test.sh set, and UCX from PKG_CONFIG_PATH above. build_tests is disabled
+# explicitly: NIXL's gtest suite did not build cleanly with the default and
+# 02-example.sh only runs the bundled example. Revisit if/when tests build.
+# Wipe build/ first because `meson setup` fails on a pre-existing one.
+(
+  cd nixl
+  rm -rf build
+  meson setup build -Dbuild_tests=false
+  ninja -C build
+)

--- a/nixl/02-example.sh
+++ b/nixl/02-example.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Run NIXL's bundled C++ example end-to-end and confirm it reports a
+# completed transfer.
+
+set -ETeuo pipefail
+
+# Point NIXL's plugin manager at the freshly-built UCX backend.
+NIXL_PLUGIN_DIR="$(realpath nixl/build/src/plugins/ucx)"
+export NIXL_PLUGIN_DIR
+
+# The UCX library NIXL was built against lives in our local install, not
+# the system path. Make sure the loader can find it at runtime.
+LD_LIBRARY_PATH="$(realpath ucx-install/lib):${LD_LIBRARY_PATH-}"
+export LD_LIBRARY_PATH
+
+# Run NIXL's bundled example, capturing output for inspection.
+./nixl/build/examples/cpp/nixl_example 2>&1 | tee test.log
+
+# The example prints "Test done" on a successful end-to-end transfer.
+# Absence of that line means the run failed, even if the program exited
+# cleanly.
+if ! grep -q "Test done" test.log; then
+  echo "Error: NIXL example did not print 'Test done' — see test.log." >&2
+  exit 1
+fi

--- a/versions.txt
+++ b/versions.txt
@@ -32,6 +32,7 @@ llama.cpp b2000
 llm.c 7ecd8906afe6ed7a2b2cdb731c042f26d525b820
 MAGMA v2.9.0
 nerf-cuda main
+nixl e128059af332df6e05de218d24b04c66a64b030a
 nvflip 1eb247c
 openmpi v4.1
 opencv 725e440
@@ -50,6 +51,7 @@ thrust 756c5af
 timemachine 01f14f8
 tiny-cuda-nn v2.0
 UppASD gpu_new
+ucx c982cef7cdfc80008c838741ff4cc38a4ce54c89
 vllm v0.6.3
 whispercpp v1.7.1
 xgboost v2.1.0


### PR DESCRIPTION
## Summary
Adds clone, build, and example scripts for NIXL (e128059), NVIDIA's network interconnect library for GPU-to-GPU transfers across heterogeneous fabrics. The validation builds NIXL against a locally-compiled UCX and runs the bundled C++ transfer example.

## Dependencies
NIXL requires UCX with multi-thread support (--enable-mt). The Ubuntu-packaged UCX (1.16) is too old and lacks APIs that NIXL uses. 00-clone.sh therefore clones UCX (c982cef) alongside NIXL, and 01-build.sh builds and installs UCX from source before building NIXL.

## Build notes
UCX is built first into ucx-install/ using autoconf. The --with-cuda flag points at the CUDA toolkit that test.sh provides via environment variables.

NIXL is then built with Meson and Ninja. Two points to note:

- PKG_CONFIG_PATH and LD_LIBRARY_PATH are updated before the NIXL build so that Meson discovers the locally-built UCX rather than the system one.
- build_tests=false is set explicitly. NIXL's gtest suite did not build cleanly against the environment; this can be revisited once the test build is fixed.

## Validation
02-example.sh runs nixl/build/examples/cpp/nixl_example and checks that the output contains Test done, which the example prints on a successful end-to-end transfer. Two environment variables are required at runtime:

- NIXL_PLUGIN_DIR - points NIXL's plugin manager at the locally-built UCX backend (nixl/build/src/plugins/ucx).
- LD_LIBRARY_PATH - includes ucx-install/lib so the loader finds the UCX shared libraries that NIXL was built against.

## Status
Passes locally on sm_75 under both native CUDA 13.1 and SCALE 1.7.0. Results are marked ? pending CI validation on the repo's target hardware.