### PR TITLE
Add COLMAP 4.0.4 to validation

### DIFF
--- a/colmap/00-clone.sh
+++ b/colmap/00-clone.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$0")"/../util/git.sh
+do_clone colmap https://github.com/colmap/colmap "$(get_version colmap)"

--- a/colmap/01-configure.sh
+++ b/colmap/01-configure.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cmake \
+    -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBLA_VENDOR="Intel10_64lp" \
+    -DCMAKE_CUDA_ARCHITECTURES="${CUDAARCHS}" \
+    -DCMAKE_CUDA_COMPILER="nvcc" \
+    -DCUDA_ENABLED="true" \
+    -DDOWNLOAD_ENABLED="false" \
+    -DUNINSTALL_ENABLED="false" \
+    -DTESTS_ENABLED="true" \
+    "colmap"

--- a/colmap/02-build.sh
+++ b/colmap/02-build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ninja

--- a/colmap/03-fetch-models.sh
+++ b/colmap/03-fetch-models.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mkdir -p .cache/colmap
+
+# prefetch models into cache since we build with -DDOWNLOAD_ENABLED=false
+wget -nc -O .cache/colmap/aliked-n16rot.onnx \
+  https://github.com/colmap/colmap/releases/download/3.13.0/aliked-n16rot.onnx
+wget -nc -O .cache/colmap/aliked-n32.onnx \
+  https://github.com/colmap/colmap/releases/download/3.13.0/aliked-n32.onnx
+wget -nc -O .cache/colmap/aliked-lightglue.onnx \
+  https://github.com/colmap/colmap/releases/download/3.13.0/aliked-lightglue.onnx
+wget -nc -O .cache/colmap/bruteforce-matcher.onnx \
+  https://github.com/colmap/colmap/releases/download/3.13.0/bruteforce-matcher.onnx
+wget -nc -O .cache/colmap/sift-lightglue.onnx \
+  https://github.com/colmap/colmap/releases/download/3.13.0/sift-lightglue.onnx

--- a/colmap/04-test.sh
+++ b/colmap/04-test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export HOME=$PWD
+ctest --output-on-failure -j$(nproc)

--- a/versions.txt
+++ b/versions.txt
@@ -64,3 +64,4 @@ gromacs v2025.4
 HeCBench 42e8f09f3f7fa922f7b7099347e70884ebe27006
 cudahandbook 5bd3f275ca5ec109b78c7612432e7f1dd04b72f7
 warp v1.14.0
+colmap 4.0.4


### PR DESCRIPTION
Currently _fails to build_ with:

```
patch_match_cuda.cu:601:27: error: no matching function for call to 'tex2DLayered'
  601 |   const float src_depth = tex2DLayered<float>(
      |                           ^~~~~~~~~~~~~~~~~~~
/opt/scale/targets/gfx1103/include/redscale_impl/builtins.h:1757:87: note: candidate template ignored: could not match 'texture<float, cudaTextureType2DLayered, readMode>' against 'cudaTextureObject_t' (aka 'unsigned long long')
 1757 | template <class DataType, enum cudaTextureReadMode readMode> __DEVICE_INLINE DataType tex2DLayered(texture<DataType, cudaTextureType2DLayered, readMode> texRef, float x, float y, int layer) { return tex2DLayered<DataType>(texRef._texObj, x, y, layer); }
      |                                                                    
```

(missing support for texture objs?)

Full build log: [build.log](https://github.com/user-attachments/files/29113205/build.log)

