### PR TITLE
add lammps to validation

### DIFF
--- a/lammps/00-clone.sh
+++ b/lammps/00-clone.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$0")"/../util/git.sh
+
+do_clone lammps https://github.com/lammps/lammps.git "$(get_version lammps)"

--- a/lammps/01-build.sh
+++ b/lammps/01-build.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# native PKG_GPU path fails due to missing -fatbin in SCALE nvcc
+
+# cmake \
+#   -S "lammps/cmake" \
+#   -B "build" \
+#   -D CMAKE_BUILD_TYPE=Release \
+#   -D BUILD_MPI=off \
+#   -D PKG_GPU=on \
+#   -D GPU_API=cuda \
+#   -D CUDA_BUILD_MULTIARCH=off \ # nvcc: error: unsupported CUDA gpu architecture: all
+#   -D GPU_ARCH="sm_${CUDAARCHS}" \
+#   -D CMAKE_CUDA_ARCHITECTURES="${CUDAARCHS}"
+
+# soooooo trying to build with PKG_KOKKOS=on + Kokkos_ENABLE_CUDA instead:
+# (which seems to work)
+
+# this is cursed, but unfortunately what KOKKOS requires? :p
+KOKKOS_ARCH="NATIVE"
+case "${CUDAARCHS:-}" in
+  70) KOKKOS_ARCH="VOLTA70" ;;
+  72) KOKKOS_ARCH="VOLTA72" ;;
+  75) KOKKOS_ARCH="TURING75" ;;
+  80) KOKKOS_ARCH="AMPERE80" ;;
+  86) KOKKOS_ARCH="AMPERE86" ;;
+  87) KOKKOS_ARCH="AMPERE87" ;;
+  89) KOKKOS_ARCH="ADA89" ;;
+  90) KOKKOS_ARCH="HOPPER90" ;;
+  120) KOKKOS_ARCH="BLACKWELL120" ;;
+esac
+
+cmake \
+  -S "lammps/cmake" \
+  -B "build" \
+  -D CMAKE_BUILD_TYPE=Release \
+  -D CMAKE_CXX_STANDARD=17 \
+  -D BUILD_MPI=off \
+  -D BUILD_OMP=off \
+  -D PKG_KOKKOS=on \
+  -D Kokkos_ENABLE_SERIAL=on \
+  -D Kokkos_ENABLE_CUDA=on \
+  -D Kokkos_ARCH_${KOKKOS_ARCH}=on \
+  -D CMAKE_CXX_COMPILER="$(realpath "lammps/lib/kokkos/bin/nvcc_wrapper")"
+
+cmake --build "build" -j"$(nproc)"

--- a/lammps/02-smoke.sh
+++ b/lammps/02-smoke.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+./build/lmp -h >/dev/null 2>&1

--- a/versions.txt
+++ b/versions.txt
@@ -30,6 +30,7 @@ hashinator 34cf188
 heraclespp a925d6a
 hypre v2.33.0
 jitify master
+lammps stable_22Jul2025_update4
 llama.cpp b9522
 llm.c 7ecd8906afe6ed7a2b2cdb731c042f26d525b820
 MAGMA v2.9.0


### PR DESCRIPTION
attempting to build thorugh the legacy `PKG_GPU` path fails due to SCALE `nvcc` not providing `-fatbin`:
```
[ 17%] Building NVCC fatbin file cuda_compile_fatbin_1_generated_lal_yukawa_colloid.cu.fatbin
nvcc: error: unknown argument '-fatbin';
```

also fails unless `CUDA_BUILD_MULTIARCH=off`

that path is present commented out in this PR

building through the Kokkos wrapper path succeeds ;and produces a seemingly usable binary that inits, (but i've not done any extensive testing)

i'm not sure if it's worth inclusion since we already have a testcase for Kokkos itself, hence opening as draft pr for now