### PR TITLE
add cp2k to suite

### DIFF
--- a/cp2k/00-clone.sh
+++ b/cp2k/00-clone.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo
+
+source "$(dirname "$0")"/../util/git.sh
+
+do_clone cp2k https://github.com/cp2k/cp2k.git "$(get_version cp2k)"

--- a/cp2k/01-build.sh
+++ b/cp2k/01-build.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo
+
+cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CUDA_COMPILER="nvcc" \
+    -DCMAKE_CUDA_ARCHITECTURES="${CUDAARCHS}" \
+    -DCP2K_USE_EVERYTHING=OFF \
+    -DCP2K_USE_ACCEL=CUDA \
+    -DCP2K_USE_CUDA=ON \
+    -DCP2K_USE_MPI=OFF \
+    -DCP2K_USE_LIBXSMM=OFF \
+    -DCP2K_USE_LIBXC=OFF \
+    -DCP2K_USE_LIBINT2=OFF \
+    -DCP2K_USE_FFTW3=OFF \
+    -DCP2K_ENABLE_DBM_GPU=ON \
+    -DCP2K_ENABLE_GRID_GPU=ON \
+    -DCP2K_ENABLE_PW_GPU=ON \
+    -DCP2K_DBCSR_USE_CPU_ONLY=OFF \
+    -B"build" \
+    "cp2k"
+
+make -O -C "build" -j"$(nproc)" cp2k-bin

--- a/cp2k/02-validate.sh
+++ b/cp2k/02-validate.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo
+
+build/bin/cp2k.ssmp --version | tee cp2k-version.txt
+grep -q "offload_cuda" cp2k-version.txt

--- a/versions.txt
+++ b/versions.txt
@@ -4,6 +4,7 @@ arrayfire v3.9.0
 bitnet 404980eecae38affa4871c3e419eae3f44536a95
 caffe 9b891540183ddc834a02b2bd81b31afae71b2153
 ctranslate2 v4.5.0
+cp2k support/v2026.1
 cuda-samples v12.9
 cudf v25.04.00
 cugraph fc880db


### PR DESCRIPTION
Fails to build due to missing CUDA::cuFFTW library/link target (SCALE only provides cuFFT, not cuFFTW)

(`DCP2K_ENABLE_PW_GPU=OFF` + patching cufftw from CMakeLists might be a viable workaround, but that would force FFTs to CPU)