### PR TITLE
Add missing gpusnek pin to versions.txt

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -65,3 +65,4 @@ HeCBench 42e8f09f3f7fa922f7b7099347e70884ebe27006
 cudahandbook 5bd3f275ca5ec109b78c7612432e7f1dd04b72f7
 warp v1.14.0
 colmap 4.0.4
+gpusnek 5aede38a1e94c10f6ca6f3b9161a0ba687b1091d


### PR DESCRIPTION
gpusnek had no `versions.txt` line, so `get_version` returned empty and the clone failed on `git checkout ""`. This pins it.
